### PR TITLE
Problem with default wgpu PowerPreference

### DIFF
--- a/the-renderer/renderer.rs
+++ b/the-renderer/renderer.rs
@@ -316,10 +316,12 @@ impl Renderer {
       .create_surface(window.clone())
       .map_err(|e| RendererError::SurfaceCreation(e.to_string()))?;
 
+    let power_preference =
+      wgpu::PowerPreference::from_env().unwrap_or(wgpu::PowerPreference::HighPerformance);
     let adapter = instance
       .request_adapter(&wgpu::RequestAdapterOptions {
-        power_preference:       wgpu::PowerPreference::LowPower,
-        compatible_surface:     Some(&surface),
+        power_preference,
+        compatible_surface: Some(&surface),
         force_fallback_adapter: false,
       })
       .await


### PR DESCRIPTION
First of all love the project!

I had a problem with running the editor and it seems to be the same problem as https://github.com/iced-rs/iced/issues/2810#issuecomment-2676080673, wgpu is trying to use my integrated amd GPU, which has some incompatibility and leads to a black screen:
<img width="1761" height="692" alt="image" src="https://github.com/user-attachments/assets/2e670f5e-de97-4a16-889c-7b77544d373d" />
Letting it use my dedicated GPU fixes it

I changed the code to try read from env first (f.ex `WGPU_POWER_PREF='low'`) or otherwise just use `PowerPreference::HighPerformance`, similar to what they did in iced: https://github.com/iced-rs/iced/pull/2813

Feel free to change it back to `PowerPreference::LowPower` if that's preferred, but the env part would still be nice